### PR TITLE
fixing k8s config target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,8 @@ apply-k8s-utils: update-k8s-conf
 	terraform init; \
 	terraform apply
 
-update-k8s-conf: eks --region <% index .Params `region` %> update-kubeconfig --name <% .Name %>-$(ENV)-<% index .Params `region` %>
+update-k8s-conf: 
+	aws eks --region <% index .Params `region` %> update-kubeconfig --name <% .Name %>-$(ENV)-<% index .Params `region` %>
 
 teardown: teardown-k8s-utils teardown-env teardown-secrets teardown-remote-state
 


### PR DESCRIPTION
If the Makefile command is not on a new tab indented line then it treats the following word as a target name with arguments. This change just ensures the command is executed. Also added the word `aws` in front as that binary name was missing.