### PR TITLE
random keepers: terraform state to keep state

### DIFF
--- a/terraform/modules/database/main.tf
+++ b/terraform/modules/database/main.tf
@@ -45,7 +45,6 @@ data "aws_secretsmanager_secret" "rds_master_secret" {
 # RDS does not support secret-manager, have to provide the actual string
 data "aws_secretsmanager_secret_version" "rds_master_secret" {
   secret_id = data.aws_secretsmanager_secret.rds_master_secret.name
-  depends_on = [data.aws_secretsmanager_secret.rds_master_secret]
 }
 
 module "rds" {

--- a/terraform/modules/secret/main.tf
+++ b/terraform/modules/secret/main.tf
@@ -22,6 +22,10 @@ resource "aws_secretsmanager_secret_version" "random_secret" {
 }
 
 resource "random_password" "random" {
+  # this allows terraform state to have an identifier for generated passwords
+  keepers = {
+    aws_secret = var.name_prefix
+  }
   count             = var.type == "random" ? 1 : 0
   length            = var.random_length
   special           = true


### PR DESCRIPTION
I'm still testing this, i tried it and couldnt seem to get it to work... 
I'm wondering if its the way `"${data.aws_secretsmanager_secret_version..secret_strirds_master_secretng}"` is read, it always thinks its new (maybe it doesnt keep a state of it?) , or maybe i did something wrong