### PR TITLE
secrets: remove name_prefix fixes

### DIFF
--- a/templates/terraform/modules/database/main.tf
+++ b/templates/terraform/modules/database/main.tf
@@ -32,8 +32,7 @@ data "aws_caller_identity" "current" {
 module "db_password" {
   source      = "../secret"
   type        = "random"
-  ## note: secret name_prefix has a limitation of 32 characters 
-  name_prefix = "${var.project}-${var.environment}-rds"
+  name = "${var.project}-${var.environment}-rds-<% index .Params `randomSeed` %>"
 }
 
 # secret declared so secret version waits for rds-secret to be ready

--- a/templates/terraform/modules/secret/main.tf
+++ b/templates/terraform/modules/secret/main.tf
@@ -1,6 +1,5 @@
 # Add the keys to AWS secrets manager
 resource "aws_secretsmanager_secret" "secret" {
-  name_prefix = var.name_prefix
   name = var.name
   tags = var.tags
 }
@@ -26,7 +25,7 @@ resource "aws_secretsmanager_secret_version" "random_secret" {
 resource "random_password" "random" {
   # this allows terraform state to have an identifier for generated passwords
   keepers = {
-    aws_secret = var.name_prefix
+    aws_secret = var.name
   }
   count             = var.type == "random" ? 1 : 0
   length            = var.random_length

--- a/templates/terraform/modules/secret/variables.tf
+++ b/templates/terraform/modules/secret/variables.tf
@@ -2,10 +2,6 @@ variable "name" {
   default = ""
   description = "The name of the secret in Secrets Manager (only one of name or name_prefix can be specified)"
 }
-variable "name_prefix" {
-  default = ""
-  description = "The name prefix of the secret in Secrets Manager - a random suffix will be appended (only one of name or name_prefix can be specified)"
-}
 
 variable type {
   description = "The type of data to hold in this secret (map, string, random)"


### PR DESCRIPTION
just realized go-getter supports branches so we can test with a branch doing, or even offer different flavors of our modules via branches 

```
func GetRegistry() Registry {
	return Registry{
		// TODO: better place to store these options as configuration file or any source
		{
			"EKS + Go + React",
			[]string{
				"github.com/commitdev/zero-aws-eks-stack?ref=fix-secret",
				"github.com/commitdev/zero-deployable-backend",
				"github.com/commitdev/zero-deployable-react-frontend",
			},
		},
		{
			"Custom", []string{},
		},
	}
}
```