### PR TITLE
Teardown improvement

### DIFF
--- a/templates/Makefile
+++ b/templates/Makefile
@@ -32,14 +32,17 @@ update-k8s-conf:
 teardown: teardown-k8s-utils teardown-env teardown-secrets teardown-remote-state
 
 teardown-remote-state:
+	@echo "Deleting remote state is not reversible, are you sure you want to delete the resources? [y/N]:" && read ans && [ $${ans:-N} == y ] && \
 	export AWS_PAGER='' && export AWS_DEFAULT_REGION=<% index .Params `region` %> && \
 	aws s3 rm s3://<% .Name %>-$(ENVIRONMENT)-terraform-state --recursive && \
 	aws s3 rb s3://<% .Name %>-$(ENVIRONMENT)-terraform-state --force && \
 	aws dynamodb delete-table --region <% index .Params `region` %> --table-name <% .Name %>-$(ENVIRONMENT)-terraform-state-locks
 
 teardown-secrets:
+	@echo "Deleting secrets is not reversible, are you sure you want to delete the secrets? [y/N]:" && read ans && [ $${ans:-N} == y ] && \
 	export AWS_PAGER='' && export AWS_DEFAULT_REGION=<% index .Params `region` %> && \
 	aws secretsmanager list-secrets --region <% index .Params `region` %> --query "SecretList[?Tags[?Key=='project' && Value=='<% .Name %>']].[Name] | [0][0]" | xargs aws secretsmanager delete-secret --region <% index .Params `region` %> --secret-id && \
+	aws secretsmanager list-secrets --region <% index .Params `region` %> --query "SecretList[?Tags[?Key=='rds' && Value=='<% .Name %>-$(ENVIRONMENT)']].[Name] | [0][0]" | xargs aws secretsmanager delete-secret --region <% index .Params `region` %> --secret-id && \
 	aws iam delete-access-key --user-name <% .Name %>-ci-user --access-key-id $(shell aws iam list-access-keys --user-name <% .Name %>-ci-user --query "AccessKeyMetadata[0].AccessKeyId" | sed 's/"//g') && \
 	aws iam delete-user --user-name <% .Name %>-ci-user
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -74,10 +74,42 @@ Commonly used links in AWS console
 |IAM        |https://console.aws.amazon.com/iam/home#/users|
 |ECR        |https://console.aws.amazon.com/ecr/repositories|
 |RDS        |https://console.aws.amazon.com/rds|
+
+### Teardown 
+Tearing down the infrastructure requires multiple steps, as some of the resources have protection mechanism so they're not accidentally deleted 
+
+_Note: the following steps are not reversible, tearing down the cluster results in lost data/resources._
+
+```
+export ENVIRONMENT=staging/production
+```
+1. Navigate to your infrastructure repository (where this readme/makefile provided is located), we will remove the resources in a Last in First out order.
+```
+make teardown-k8s-utils
+```
+
+2. Disable the RDS delete protection of the database https://console.aws.amazon.com/rds. Goal is to delete the entire database, so make sure you **backup your database before going so**.
+
+3. Empty the s3 bucket for your frontend assets, http://s3.console.aws.amazon.com/s3/home
+
+4. teardown the EKS cluster and VPC with the following command:
+```
+make teardown-env
+```
+5. teardown the secrets created for CI and RDS with the following command:
+```
+make teardown-secrets
+```
+6. Empty the s3 bucket for your terraform backend, http://s3.console.aws.amazon.com/s3/home
+7. teardown the dynamodb and terraform backend with the following command:
+```
+make teardown-remote-state
+```
+
 ### Suggested readings
 - [Terraform workflow][tf-workflow]
 - [Why do I want code as infrastructure][why-infra-as-code]
-- 
+
 
 
 <!-- Links -->

--- a/templates/terraform/bootstrap/secrets/main.tf
+++ b/templates/terraform/bootstrap/secrets/main.tf
@@ -31,3 +31,19 @@ module "ci_user_keys" {
   values  = map("access_key_id", aws_iam_access_key.ci_user.id, "secret_key", aws_iam_access_key.ci_user.secret)
   tags = map("project", local.project)
 }
+
+module "rds_master_secret_staging" {
+  source  = "../../modules/secret"
+  name = "${local.project}-staging-rds-<% index .Params `randomSeed` %>"
+  type          = "random"	
+  random_length = 32
+  tags = map("rds", "${local.project}-staging")
+}
+
+module "rds_master_secret_production" {
+  source  = "../../modules/secret"
+  name = "${local.project}-production-rds-<% index .Params `randomSeed` %>"
+  type          = "random"	
+  random_length = 32
+  tags = map("rds", "${local.project}-production")
+}

--- a/templates/terraform/modules/database/main.tf
+++ b/templates/terraform/modules/database/main.tf
@@ -28,17 +28,10 @@ module "rds_security_group" {
 data "aws_caller_identity" "current" {
 }
 
-# creating RDS password in secret-manager
-module "db_password" {
-  source      = "../secret"
-  type        = "random"
-  name = "${var.project}-${var.environment}-rds-<% index .Params `randomSeed` %>"
-}
-
 # secret declared so secret version waits for rds-secret to be ready
 # or else we often see a AWSDEFAULT VERSION secret not found error
 data "aws_secretsmanager_secret" "rds_master_secret" {
-  name = module.db_password.secret_name
+  name = "${var.project}-${var.environment}-rds-<% index .Params `randomSeed` %>"
 }
 
 # RDS does not support secret-manager, have to provide the actual string


### PR DESCRIPTION
previously we had secret moved into `env` so it can be referenced as a resource with the unknown name-prefix timestamp

moving it back to secrets 