### PR TITLE
fix: incorrect database variable reference

### DIFF
--- a/templates/terraform/modules/database/main.tf
+++ b/templates/terraform/modules/database/main.tf
@@ -9,7 +9,7 @@ module "rds_security_group" {
 
   number_of_computed_ingress_with_source_security_group_id = 1
   computed_ingress_with_source_security_group_id = [
-    var.database == "postgres" ? {
+    var.database_engine == "postgres" ? {
       from_port   = 5432
       to_port     = 5432
       protocol    = "tcp"


### PR DESCRIPTION
missed this when I was renaming the variable, should be https://github.com/commitdev/zero-aws-eks-stack/blob/master/templates/terraform/modules/database/variables.tf#L25