### PR TITLE
fix: exec locally instead of aws_eks_cluster_auth

### DIFF
--- a/templates/Makefile
+++ b/templates/Makefile
@@ -28,7 +28,7 @@ apply-k8s-utils: update-k8s-conf
 	terraform apply $(AUTO_APPROVE)
 
 update-k8s-conf:
-	aws eks --region <% index .Params `region` %> update-kubeconfig --name $(PROJECT)-$(ENVIRONMENT)-<% index .Params `region` %>
+	aws eks --region <% index .Params `region` %> update-kubeconfig --role "arn:aws:iam::<% index .Params `accountId` %>:role/$(PROJECT)-kubernetes-admin-$(ENVIRONMENT)" --name $(PROJECT)-$(ENVIRONMENT)-<% index .Params `region` %>
 
 post-apply-setup:
 	cd scripts && ENVIRONMENT=$(ENVIRONMENT) PROJECT=$(PROJECT) sh post-apply.sh

--- a/templates/kubernetes/terraform/modules/kubernetes/provider.tf
+++ b/templates/kubernetes/terraform/modules/kubernetes/provider.tf
@@ -14,3 +14,20 @@ provider "kubernetes" {
   token                  = data.aws_eks_cluster_auth.cluster_auth.token
   load_config_file       = false
 }
+provider "kubernetes" {
+  ## This is a workaround because aws-eks-cluster-auth will default to us-east-1
+  ## leading to an invalid token to access the cluster
+  exec {
+    api_version = "client.authentication.k8s.io/v1alpha1"
+    command     = "aws"
+    args        = [
+      "eks",
+      "get-token",
+      "--region",
+      var.region,
+      "--cluster-name",
+      var.cluster_name,
+      "--role",
+      "arn:aws:iam::${data.aws_caller_identity.account_id}:role/${var.project}-kubernetes-admin-${var.environment}"]
+  }
+}


### PR DESCRIPTION
token generated by the data.aws_eks_cluster_auth has a bug where it
generates a token for the wrong region, leading to other users cannot
`terraform plan` even though they have the correct permission