### PR TITLE
zero-268: set s3_hosting module cf_signed_downloads 

### DIFF
--- a/templates/terraform/environments/prod/main.tf
+++ b/templates/terraform/environments/prod/main.tf
@@ -39,6 +39,7 @@ module "prod" {
     "<% index .Params `productionFrontendSubdomain` %><% index .Params `productionHostRoot` %>",
   ]
   domain_name = "<% index .Params `productionHostRoot` %>"
+  cf_signed_downloads = <% if eq (index .Params `fileUploads`) "yes" %>true<% else %>false<% end %>
 
   # DB configuration
   database = "<% index .Params `database` %>"

--- a/templates/terraform/environments/stage/main.tf
+++ b/templates/terraform/environments/stage/main.tf
@@ -39,6 +39,7 @@ module "stage" {
     "<% index .Params `stagingFrontendSubdomain` %><% index .Params `stagingHostRoot` %>",
   ]
   domain_name = "<% index .Params `stagingHostRoot` %>"
+  cf_signed_downloads = <% if eq (index .Params `fileUploads`) "yes" %>true<% else %>false<% end %>
 
   # This will save some money as there a cost associated to each NAT gateway, but if the AZ with the gateway
   # goes down, nothing in the private subnets will be able to reach the internet. Not recommended for production.

--- a/templates/terraform/modules/environment/main.tf
+++ b/templates/terraform/modules/environment/main.tf
@@ -71,6 +71,7 @@ module "s3_hosting" {
   # We need to wait for certificate validation to complete before using the certs
   depends_on = [module.assets_domains.certificate_validations]
 
+  cf_signed_downloads     = var.cf_signed_downloads
   buckets                 = var.s3_hosting_buckets
   project                 = var.project
   environment             = var.environment

--- a/templates/terraform/modules/environment/variables.tf
+++ b/templates/terraform/modules/environment/variables.tf
@@ -137,3 +137,9 @@ variable "sendgrid_api_key_secret_name" {
   description = "AWS secret manager's secret name storing the sendgrid api key"
   type  = string
 }
+
+variable "cf_signed_downloads" {
+  type        = bool
+  description = "Enable Cloudfront signed URLs"
+  default     = false
+}


### PR DESCRIPTION
Set s3_hosting module cf_signed_downloads param based on questionnaire

https://app.zenhub.com/workspaces/commit-zero-5da8decc7046a60001c6db44/issues/commitdev/zero/268

- Use templates to set s3_hosting.cf_signed_downloads to true or false based on the questionnaire for using s3 file uploads and CF signed download URLs.