### PR TITLE
fix: syntax to support older bash versions

### DIFF
--- a/templates/scripts/add-vpn-user.sh
+++ b/templates/scripts/add-vpn-user.sh
@@ -70,7 +70,7 @@ Address = $next_ip/32
 # VPN server side
 PublicKey = $server_public_key
 AllowedIPs = 0.0.0.0/0
-Endpoint = vpn.$EXTERNAL_DNS:51820
+Endpoint = $EXTERNAL_DNS:51820
 
 EOF
 

--- a/templates/scripts/add-vpn-user.sh
+++ b/templates/scripts/add-vpn-user.sh
@@ -69,7 +69,7 @@ Address = $next_ip/32
 [Peer]
 # VPN server side
 PublicKey = $server_public_key
-AllowedIPs = 0.0.0.0/0
+AllowedIPs = 10.10.0.0/16
 Endpoint = $EXTERNAL_DNS:51820
 
 EOF

--- a/templates/scripts/add-vpn-user.sh
+++ b/templates/scripts/add-vpn-user.sh
@@ -25,7 +25,7 @@ client_public_key=$($EXEC "echo -n $client_private_key | wg pubkey")
 
 # get next available IP
 existing_ips=$($EXEC "cat /etc/wireguard/wg0.conf | grep AllowedIPs| cut -d\" \" -f3 | cut -d\"/\" -f1 | sort")
-last_ip=$(echo "$existing_ips" | tr -cd "[:alnum:].\n" | tail -1)
+last_ip=$(echo "$existing_ips" | tr -cd "[:alnum:]." | tail -1)
 next_ip=$last_ip
 while [[ "$existing_ips" =~ "$next_ip" ]]; do
   next_ip=${next_ip%.*}.$((${next_ip##*.}+1))

--- a/templates/scripts/add-vpn-user.sh
+++ b/templates/scripts/add-vpn-user.sh
@@ -25,7 +25,7 @@ client_public_key=$($EXEC "echo -n $client_private_key | wg pubkey")
 
 # get next available IP
 existing_ips=$($EXEC "cat /etc/wireguard/wg0.conf | grep AllowedIPs| cut -d\" \" -f3 | cut -d\"/\" -f1 | sort")
-last_ip=$(echo "$existing_ips" | tail -1)
+last_ip=$(echo "$existing_ips" | tr -cd "[:alnum:].\n" | tail -1)
 next_ip=$last_ip
 while [[ "$existing_ips" =~ "$next_ip" ]]; do
   next_ip=${next_ip%.*}.$((${next_ip##*.}+1))


### PR DESCRIPTION
the pipes confuses older bash versions to run commands after
pipe locally instead of passing to remote

with help from @sshi100 we found out in `bash 3.x` it gets confused and tries to run `wg` locally
and in `bash 5.x` it works fine