### PR TITLE
zero-235: Document Hosting Support

### DIFF
--- a/templates/kubernetes/terraform/environments/prod/application_iam_policy.tf
+++ b/templates/kubernetes/terraform/environments/prod/application_iam_policy.tf
@@ -1,3 +1,6 @@
+locals {
+  domain_name = "<% index .Params `productionHostRoot` %>"
+}
 
 # define policy documents for backend services
 # sample policies
@@ -8,6 +11,14 @@ data "aws_iam_policy_document" "resource_access_backendservice" {
       "ec2:Describe*",
     ]
     resources = ["arn:aws:ec2:::prod-*"]
+  }
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+    ]
+    resources = ["arn:aws:s3:::files.${local.domain_name}/*"]
   }
   # can be more statements here
 }

--- a/templates/kubernetes/terraform/environments/stage/application_iam_policy.tf
+++ b/templates/kubernetes/terraform/environments/stage/application_iam_policy.tf
@@ -1,3 +1,6 @@
+locals {
+  domain_name = "<% index .Params `stagingHostRoot` %>"
+}
 
 # define policy documents for backend services
 # sample policies
@@ -8,6 +11,14 @@ data "aws_iam_policy_document" "resource_access_backendservice" {
       "ec2:Describe*",
     ]
     resources = ["arn:aws:ec2:::stage-*"]
+  }
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+    ]
+    resources = ["arn:aws:s3:::files.${local.domain_name}/*"]
   }
   # can be more statements here
 }

--- a/templates/terraform/environments/prod/main.tf
+++ b/templates/terraform/environments/prod/main.tf
@@ -7,6 +7,13 @@ terraform {
     region         = "<% index .Params `region` %>"
     dynamodb_table = "<% .Name %>-prod-terraform-state-locks"
   }
+
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      version = "~> 3.7"
+    }
+  }
 }
 
 locals {
@@ -59,11 +66,12 @@ module "prod" {
 
   # Hosting configuration. Each domain will have a bucket created for it, but may have mulitple aliases pointing to the same bucket.
   hosted_domains = [
-    { domain : local.domain_name, aliases : [] },
-    { domain : "<% index .Params `productionFrontendSubdomain` %>${local.domain_name}", aliases : [] },
+    { domain : local.domain_name, aliases : [], signed_urls: false },
+    { domain : "<% index .Params `productionFrontendSubdomain` %>${local.domain_name}", aliases : [], signed_urls: false },
+    <% if eq (index .Params `fileUploads`) "yes" %>{ domain : "files.${local.domain_name}", aliases : [], signed_urls: true },<% end %>
   ]
-  domain_name = "${local.domain_name}"
-  cf_signed_downloads = <% if eq (index .Params `fileUploads`) "yes" %>true<% else %>false<% end %>
+
+  domain_name = local.domain_name
 
   # DB configuration
   database = "<% index .Params `database` %>"

--- a/templates/terraform/environments/stage/main.tf
+++ b/templates/terraform/environments/stage/main.tf
@@ -7,6 +7,13 @@ terraform {
     region         = "<% index .Params `region` %>"
     dynamodb_table = "<% .Name %>-stage-terraform-state-locks"
   }
+
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      version = "~> 3.7"
+    }
+  }
 }
 
 locals {
@@ -57,13 +64,13 @@ module "stage" {
   # https://${local.region}.console.aws.amazon.com/systems-manager/parameters/%252Faws%252Fservice%252Feks%252Foptimized-ami%252F1.17%252Famazon-linux-2%252Frecommended%252Fimage_id/description?region=${local.region}
   eks_worker_ami = "<% index .Params `eksWorkerAMI` %>"
 
-  # Hosting configuration. Each domain will have a bucket created for it, but may have mulitple aliases pointing to the same bucket.
   hosted_domains = [
-    { domain : local.domain_name, aliases : [] },
-    { domain : "<% index .Params `stagingFrontendSubdomain` %>${local.domain_name}", aliases : [] },
+    { domain : local.domain_name, aliases : [], signed_urls: false },
+    { domain : "<% index .Params `stagingFrontendSubdomain` %>${local.domain_name}", aliases : [], signed_urls: false },
+    <% if eq (index .Params `fileUploads`) "yes" %>{ domain : "files.${local.domain_name}", aliases : [], signed_urls: true },<% end %>
   ]
+
   domain_name = local.domain_name
-  cf_signed_downloads = <% if eq (index .Params `fileUploads`) "yes" %>true<% else %>false<% end %>
 
   # This will save some money as there a cost associated to each NAT gateway, but if the AZ with the gateway
   # goes down, nothing in the private subnets will be able to reach the internet. Not recommended for production.

--- a/templates/terraform/modules/environment/main.tf
+++ b/templates/terraform/modules/environment/main.tf
@@ -36,7 +36,6 @@ module "vpc" {
 # To get the current account id
 data "aws_caller_identity" "current" {}
 
-
 #
 # Provision the EKS cluster
 module "eks" {
@@ -91,7 +90,7 @@ module "s3_hosting" {
   version = "0.1.0"
   count   = length(var.hosted_domains)
 
-  cf_signed_downloads    = var.cf_signed_downloads
+  cf_signed_downloads    = var.hosted_domains[count.index].signed_urls
   domain                 = var.hosted_domains[count.index].domain
   aliases                = var.hosted_domains[count.index].aliases
   project                = var.project

--- a/templates/terraform/modules/environment/variables.tf
+++ b/templates/terraform/modules/environment/variables.tf
@@ -49,6 +49,7 @@ variable "hosted_domains" {
   type = list( object( {
     domain  = string
     aliases = list(string)
+    signed_urls = bool
   } ) )
 }
 
@@ -139,12 +140,6 @@ variable "sendgrid_enabled" {
 variable "sendgrid_api_key_secret_name" {
   description = "AWS secret manager's secret name storing the sendgrid api key"
   type  = string
-}
-
-variable "cf_signed_downloads" {
-  type        = bool
-  description = "Enable Cloudfront signed URLs"
-  default     = false
 }
 
 variable "roles" {


### PR DESCRIPTION
fix: correct authorization for s3 access for backend service
improvement: leverage multiple domains support for file uploads backend
fix: pin aws provider version

- specify required hashicorp/aws version for aws provider
- add 'signed_urls' to hosted_domains variable
- conditionally define files bucket as part of hosted_domains

application_iam_policy
- set 'domain_name' to local var
- add new s3 get/put policy

https://app.zenhub.com/workspaces/commit-zero-5da8decc7046a60001c6db44/issues/commitdev/zero/235