### PR TITLE
Small fix to vpn output - carriage return was messing up the formatting

### DIFF
--- a/templates/kubernetes/terraform/modules/kubernetes/vpn.tf
+++ b/templates/kubernetes/terraform/modules/kubernetes/vpn.tf
@@ -137,6 +137,8 @@ resource "kubernetes_deployment" "wireguard" {
       metadata {
         labels = {
           app = "wireguard"
+          # this hash is to update the deployment whenever configmap is updated with new users
+          configmap_version = sha1(data.template_file.vpn_server_conf.rendered)
         }
       }
 

--- a/templates/scripts/add-vpn-user.sh
+++ b/templates/scripts/add-vpn-user.sh
@@ -21,7 +21,7 @@ read name
 # collect keys
 server_public_key=$($EXEC "cat /etc/wireguard/privatekey | wg pubkey")
 client_private_key=$($EXEC "wg genkey")
-client_public_key=$($EXEC "echo -n $client_private_key | wg pubkey")
+client_public_key=$($EXEC "echo -n $client_private_key | wg pubkey | tr -d \"\r\n\f\"")
 
 # get next available IP
 existing_ips=$($EXEC "cat /etc/wireguard/wg0.conf | grep AllowedIPs| cut -d\" \" -f3 | cut -d\"/\" -f1 | sort")
@@ -45,7 +45,7 @@ echo
 echo "Please modify kubernetes/terraform/environments/<env>/main.tf and append the following line to var.vpn_client_publickeys."
 echo "Then apply the terraform, or ask an administrator to."
 echo
-printf '    ["%s", "%s", "%s"]' "$name" "$next_ip/32" "$client_public_key"
+printf '    ["%s", "%s", "%s"],' "$name" "$next_ip/32" "$client_public_key"
 echo
 echo "After this is done you should be able to open the wireguard client and activate the tunnel."
 echo "You can download the client at https://www.wireguard.com/install/"

--- a/templates/scripts/add-vpn-user.sh
+++ b/templates/scripts/add-vpn-user.sh
@@ -25,7 +25,7 @@ client_public_key=$($EXEC "echo -n $client_private_key | wg pubkey | tr -d \"\r\
 
 # get next available IP
 existing_ips=$($EXEC "cat /etc/wireguard/wg0.conf | grep AllowedIPs| cut -d\" \" -f3 | cut -d\"/\" -f1 | sort")
-last_ip=$(echo "$existing_ips" | tr -cd "[:alnum:]." | tail -1)
+last_ip=$(echo "$existing_ips" | tr -cd "[:alnum:].\n" | tail -1)
 next_ip=$last_ip
 while [[ "$existing_ips" =~ "$next_ip" ]]; do
   next_ip=${next_ip%.*}.$((${next_ip##*.}+1))


### PR DESCRIPTION
After running the command my output looked like this:
```
"]  ["bill", "10.10.199.203/32", "asdf
```

Now it should look like this:
```
    ["bill", "10.10.199.203/32", "asdf"],
```