### PR TITLE
Added support for allow domain aliases

### DIFF
--- a/templates/terraform/environments/prod/main.tf
+++ b/templates/terraform/environments/prod/main.tf
@@ -38,10 +38,10 @@ module "prod" {
   # https://<% index .Params `region` %>.console.aws.amazon.com/systems-manager/parameters/%252Faws%252Fservice%252Feks%252Foptimized-ami%252F1.17%252Famazon-linux-2%252Frecommended%252Fimage_id/description?region=<% index .Params `region` %>
   eks_worker_ami = "<% index .Params `eksWorkerAMI` %>"
 
-  # Hosting configuration
-  s3_hosting_buckets = [
-    "<% index .Params `productionHostRoot` %>",
-    "<% index .Params `productionFrontendSubdomain` %><% index .Params `productionHostRoot` %>",
+  # Hosting configuration. Each domain will have a bucket created for it, but may have mulitple aliases pointing to the same bucket.
+  hosted_domains = [
+    { domain : "<% index .Params `productionHostRoot` %>", aliases : [] },
+    { domain : "<% index .Params `productionFrontendSubdomain` %><% index .Params `productionHostRoot` %>", aliases : [] },
   ]
   domain_name = "<% index .Params `productionHostRoot` %>"
   cf_signed_downloads = <% if eq (index .Params `fileUploads`) "yes" %>true<% else %>false<% end %>

--- a/templates/terraform/environments/stage/main.tf
+++ b/templates/terraform/environments/stage/main.tf
@@ -38,10 +38,10 @@ module "stage" {
   # https://<% index .Params `region` %>.console.aws.amazon.com/systems-manager/parameters/%252Faws%252Fservice%252Feks%252Foptimized-ami%252F1.17%252Famazon-linux-2%252Frecommended%252Fimage_id/description?region=<% index .Params `region` %>
   eks_worker_ami = "<% index .Params `eksWorkerAMI` %>"
 
-  # Hosting configuration
-  s3_hosting_buckets = [
-    "<% index .Params `stagingHostRoot` %>",
-    "<% index .Params `stagingFrontendSubdomain` %><% index .Params `stagingHostRoot` %>",
+  # Hosting configuration. Each domain will have a bucket created for it, but may have mulitple aliases pointing to the same bucket.
+  hosted_domains = [
+    { domain : "<% index .Params `stagingHostRoot` %>", aliases : [] },
+    { domain : "<% index .Params `stagingFrontendSubdomain` %><% index .Params `stagingHostRoot` %>", aliases : [] },
   ]
   domain_name = "<% index .Params `stagingHostRoot` %>"
   cf_signed_downloads = <% if eq (index .Params `fileUploads`) "yes" %>true<% else %>false<% end %>

--- a/templates/terraform/modules/environment/iam.tf
+++ b/templates/terraform/modules/environment/iam.tf
@@ -72,7 +72,7 @@ data "aws_iam_policy_document" "deploy_assets_policy" {
       "s3:ListBucket",
     ]
 
-    resources = formatlist("arn:aws:s3:::%s", var.s3_hosting_buckets)
+    resources = module.s3_hosting[*].bucket_arn
   }
 
   statement {
@@ -81,7 +81,7 @@ data "aws_iam_policy_document" "deploy_assets_policy" {
       "s3:GetBucketLocation",
     ]
 
-    resources = formatlist("arn:aws:s3:::%s/*", var.s3_hosting_buckets)
+    resources = formatlist("%s/*", module.s3_hosting[*].bucket_arn)
   }
 
   statement {

--- a/templates/terraform/modules/environment/provider.tf
+++ b/templates/terraform/modules/environment/provider.tf
@@ -3,6 +3,11 @@ data "aws_iam_role" "eks_cluster_creator" {
   name = "${var.project}-eks-cluster-creator"
 }
 
+provider "aws" {
+  alias = "for_cloudfront"
+  region = "us-east-1"
+}
+
 # Used only for EKS creation to tie "cluster creator" to a role instead of the user who runs terraform
 # This allows us to rely on credentials pulled from the EKS cluster instead of the user's local kube config
 provider "aws" {

--- a/templates/terraform/modules/environment/variables.tf
+++ b/templates/terraform/modules/environment/variables.tf
@@ -44,9 +44,12 @@ variable "eks_worker_ami" {
   description = "The (EKS-optimized) AMI for EKS worker instances"
 }
 
-variable "s3_hosting_buckets" {
-  description = "S3 hosting buckets"
-  type = set(string)
+variable "hosted_domains" {
+  description = "Domains to host content for using S3 and Cloudfront. Requires a domain which will be the bucket name and the domain for the certificate, and optional aliases which will have records created for them and will be SubjectAltNames for the certificate. Only a single bucket and CF Distribution will be created per domain."
+  type = list( object( {
+    domain  = string
+    aliases = list(string)
+  } ) )
 }
 
 variable "domain_name" {


### PR DESCRIPTION
Updated to new versions of certificates and hosting modules, changed args correspondingly.
Use alternate provider instead of providing region to cert, to match Aaron's change.

terraform-aws-zero/#7
