### PR TITLE
Lint status badge

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -34,21 +34,31 @@ jobs:
       run: |
         cd ${GITHUB_WORKSPACE}/temp-project
         zero create
-    - name: Terraform Init and Validate
-      id: init_and_validate
+    - name: Set validation targets
+      id: set_validation_targets
       run: |
         INFRA_DIR=${GITHUB_WORKSPACE}/temp-project/infrastructure
+
         ## Defining test targets per line, last line ends with double quote
-        TERRAFORM_TEST_TARGETS="${INFRA_DIR}/terraform/bootstrap/remote-state
+        echo "${INFRA_DIR}/terraform/bootstrap/remote-state
         ${INFRA_DIR}/terraform/bootstrap/secrets
         ${INFRA_DIR}/terraform/environments/stage
         ${INFRA_DIR}/terraform/environments/prod
         ${INFRA_DIR}/kubernetes/terraform/environments/stage
-        ${INFRA_DIR}/kubernetes/terraform/environments/prod"
-
-        for dir in $TERRAFORM_TEST_TARGETS; do
+        ${INFRA_DIR}/kubernetes/terraform/environments/prod" > ${GITHUB_WORKSPACE}/validation-targets.conf
+    - name: Terraform Init
+      id: terraform_init
+      run: |
+        for dir in $(cat ${GITHUB_WORKSPACE}/validation-targets.conf); do
           echo "Linting ${dir}"
           cd $dir
           terraform init -backend=false
+        done
+    - name: Terraform Validate
+      id: terraform_validate
+      run: |
+        for dir in $(cat ${GITHUB_WORKSPACE}/validation-targets.conf); do
+          echo "Validating ${dir}"
+          cd $dir
           terraform validate -no-color
         done

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Overview
+[![Validation Status](https://github.com/commitdev/zero-aws-eks-stack/workflows/Validate%20Terraform/badge.svg)](https://github.com/commitdev//zero-aws-eks-stack/actions)
+
 A set of templates meant to work with [Zero], the templated result is a ready to scale infrastructure boilerplate built on top of AWS EKS baked with all best practices we have accumulated.
 
 ## Repository structure

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Overview
-[![Validation Status](https://github.com/commitdev/zero-aws-eks-stack/workflows/Validate%20Terraform/badge.svg)](https://github.com/commitdev//zero-aws-eks-stack/actions)
+[![Validation Status](https://github.com/commitdev/zero-aws-eks-stack/workflows/Validate%20Terraform/badge.svg)](https://github.com/commitdev/zero-aws-eks-stack/actions)
 
 A set of templates meant to work with [Zero], the templated result is a ready to scale infrastructure boilerplate built on top of AWS EKS baked with all best practices we have accumulated.
 


### PR DESCRIPTION
Now the init / validate steps are separate, 
but note that `init` will still catch some syntax errors
but validation will catch things like type validation (declared as list but passed in string)

![image](https://user-images.githubusercontent.com/1787590/94476859-0fb6d400-019f-11eb-89b6-6b61f57c4fe2.png)
