### PR TITLE
add S3 encryption

### DIFF
--- a/templates/terraform/bootstrap/remote-state/main.tf
+++ b/templates/terraform/bootstrap/remote-state/main.tf
@@ -10,6 +10,14 @@ resource "aws_s3_bucket" "terraform_remote_state" {
   versioning {
     enabled = true
   }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 }
 
 resource "aws_s3_bucket_public_access_block" "terraform_remote_state" {

--- a/templates/terraform/environments/prod/user_access.tf
+++ b/templates/terraform/environments/prod/user_access.tf
@@ -72,6 +72,18 @@ data "aws_iam_policy_document" "operator_access" {
     actions   = ["s3:*"]
     resources = ["arn:aws:s3:::*${local.domain_name}/*"]
   }
+
+  # CloudTrail
+  statement {
+    effect    = "Allow"
+    actions   = ["s3:ListBucket"]
+    resources = ["arn:aws:s3:::${local.project}-prod-cloudtrail"]
+  }
+  statement {
+    effect    = "Allow"
+    actions   = ["s3:GetObject", "s3:PutObject"]
+    resources = ["arn:aws:s3:::${local.project}-prod-cloudtrail/*"]
+  }
 }
 
 

--- a/templates/terraform/environments/stage/user_access.tf
+++ b/templates/terraform/environments/stage/user_access.tf
@@ -72,6 +72,18 @@ data "aws_iam_policy_document" "operator_access" {
     actions   = ["s3:*"]
     resources = ["arn:aws:s3:::*${local.domain_name}/*"]
   }
+
+  # CloudTrail
+  statement {
+    effect    = "Allow"
+    actions   = ["s3:ListBucket"]
+    resources = ["arn:aws:s3:::${local.project}-stage-cloudtrail"]
+  }
+  statement {
+    effect    = "Allow"
+    actions   = ["s3:GetObject", "s3:PutObject"]
+    resources = ["arn:aws:s3:::${local.project}-stage-cloudtrail/*"]
+  }
 }
 
 


### PR DESCRIPTION
Changes:
- Enabled S3 encryption for remote state bucket
- Enabled S3 encryption for s3 hosting (see modules https://github.com/commitdev/terraform-aws-zero/pull/23)
- Enabled S3 encryption for cloudtrail (see modules https://github.com/commitdev/terraform-aws-zero/pull/23)
- Allow operator group to access cloudtrail bucket