### PR TITLE
285 make ci user with module user_access

### DIFF
--- a/templates/Makefile
+++ b/templates/Makefile
@@ -23,7 +23,7 @@ apply-shared-remote-state:
 	rm ./terraform.tfstate )
 
 apply-secrets:
-        aws secretsmanager list-secrets --filters "Key=name,Values=$(PROJECT)-$(ENVIRONMENT)-rds-<% index .Params `randomSeed` %>" > /dev/null 2>&1 || ( \
+	aws secretsmanager list-secrets --filters "Key=name,Values=$(PROJECT)-$(ENVIRONMENT)-rds-<% index .Params `randomSeed` %>" > /dev/null 2>&1 || ( \
 	cd terraform/bootstrap/secrets && \
 	terraform init && \
 	terraform apply $(AUTO_APPROVE) && \

--- a/templates/Makefile
+++ b/templates/Makefile
@@ -23,7 +23,7 @@ apply-shared-remote-state:
 	rm ./terraform.tfstate )
 
 apply-secrets:
-	aws iam list-access-keys --user-name $(PROJECT)-ci-user > /dev/null 2>&1 || ( \
+        aws secretsmanager list-secrets --filters "Key=name,Values=$(PROJECT)-$(ENVIRONMENT)-rds-<% index .Params `randomSeed` %>" > /dev/null 2>&1 || ( \
 	cd terraform/bootstrap/secrets && \
 	terraform init && \
 	terraform apply $(AUTO_APPROVE) && \
@@ -81,8 +81,6 @@ teardown-secrets:
 	aws secretsmanager list-secrets --region $(AWS_DEFAULT_REGION) --query "SecretList[?Tags[?Key=='sendgrid' && Value=='$(PROJECT)']].[Name] | [0][0]" | xargs aws secretsmanager delete-secret --region $(AWS_DEFAULT_REGION) --secret-id || echo "Secret already removed"
 	aws secretsmanager list-secrets --region $(AWS_DEFAULT_REGION) --query "SecretList[?Tags[?Key=='cf_keypair' && Value=='$(PROJECT)']].[Name] | [0][0]" | xargs aws secretsmanager delete-secret --region $(AWS_DEFAULT_REGION) --secret-id || echo "Secret already removed"
 	aws secretsmanager list-secrets --region $(AWS_DEFAULT_REGION) --query "SecretList[?Tags[?Key=='wg' && Value=='$(PROJECT)-$(ENVIRONMENT)']].[Name] | [0][0]" | xargs aws secretsmanager delete-secret --region $(AWS_DEFAULT_REGION) --secret-id || echo "Secret already removed"
-	aws iam list-access-keys --user-name $(PROJECT)-ci-user --query "AccessKeyMetadata[0].AccessKeyId" --out text | xargs aws iam delete-access-key --user-name $(PROJECT)-ci-user --access-key-id
-	aws iam delete-user --user-name $(PROJECT)-ci-user
 	aws iam list-role-policies --role-name $(PROJECT)-eks-cluster-creator --query "PolicyNames"   | jq -r ".[]" | xargs -n1 aws iam delete-role-policy --role-name $(PROJECT)-eks-cluster-creator --policy-name
 	aws iam list-attached-role-policies --role-name $(PROJECT)-eks-cluster-creator --query "AttachedPolicies[].PolicyArn" | jq -r ".[]" | xargs -n1 aws iam detach-role-policy --role-name $(PROJECT)-eks-cluster-creator --policy-arn
 	aws iam delete-role --role-name $(PROJECT)-eks-cluster-creator

--- a/templates/scripts/add-vpn-user.sh
+++ b/templates/scripts/add-vpn-user.sh
@@ -45,7 +45,7 @@ dns_server=$(k8s_exec "cat /etc/resolv.conf | grep nameserver | tail -1 | cut -d
 VPCNAME=${CLUSTER%-$REGION}-vpc
 vpc_cidr=$(aws ec2 describe-vpcs --filters Name=tag:Name,Values=${VPCNAME} | jq -r '.Vpcs[].CidrBlock')
 [[ -z "$vpc_cidr" ]] && vpc_cidr="10.10.0.0/16"
-k8s_cidr = "172.16.0.0/12"
+k8s_cidr="172.16.0.0/12"
 
 # get Endpoint DNS
 EXTERNAL_DNS=$(kubectl -nvpn get svc wireguard -o jsonpath='{.metadata.annotations.external-dns\.alpha\.kubernetes\.io/hostname}')

--- a/templates/terraform/bootstrap/secrets/main.tf
+++ b/templates/terraform/bootstrap/secrets/main.tf
@@ -13,28 +13,6 @@ provider "aws" {
   allowed_account_ids = [local.aws_account_id]
 }
 
-# Create the CI User
-resource "aws_iam_user" "ci_user" {
-  name = "${local.project}-ci-user"
-}
-
-# Create a keypair to be used by CI systems
-resource "aws_iam_access_key" "ci_user" {
-  user = aws_iam_user.ci_user.name
-}
-
-# Add the keys to AWS secrets manager
-module "ci_user_keys" {
-  source  = "commitdev/zero/aws//modules/secret"
-  version = "0.0.2"
-
-
-  name   = "ci-user-aws-keys<% index .Params `randomSeed` %>"
-  type   = "map"
-  values = map("access_key_id", aws_iam_access_key.ci_user.id, "secret_key", aws_iam_access_key.ci_user.secret)
-  tags   = map("project", local.project)
-}
-
 module "rds_master_secret_stage" {
   source  = "commitdev/zero/aws//modules/secret"
   version = "0.0.2"

--- a/templates/terraform/environments/prod/main.tf
+++ b/templates/terraform/environments/prod/main.tf
@@ -115,22 +115,18 @@ module "prod" {
       name         = "developer"
       aws_policy   = data.aws_iam_policy_document.developer_access.json
       k8s_policies = local.k8s_developer_access
-      k8s_groups   = local.k8s_developer_groups
     },
     {
       name         = "operator"
       aws_policy   = data.aws_iam_policy_document.operator_access.json
       k8s_policies = local.k8s_operator_access
-      k8s_groups   = local.k8s_operator_groups
     },
     {
       name         = "deployer"
       aws_policy   = data.aws_iam_policy_document.deployer_access.json
       k8s_policies = local.k8s_deployer_access
-      k8s_groups   = local.k8s_deployer_groups
     }
   ]
 
   user_role_mapping = data.terraform_remote_state.shared.outputs.user_role_mapping
-  ci_users          = data.terraform_remote_state.shared.outputs.ci_users
 }

--- a/templates/terraform/environments/prod/main.tf
+++ b/templates/terraform/environments/prod/main.tf
@@ -65,6 +65,7 @@ module "prod" {
   # https://<% index .Params `region` %>.console.aws.amazon.com/systems-manager/parameters/%252Faws%252Fservice%252Feks%252Foptimized-ami%252F1.17%252Famazon-linux-2%252Frecommended%252Fimage_id/description?region=<% index .Params `region` %>
   eks_worker_ami = "<% index .Params `eksWorkerAMI` %>"
 
+  # Hosting configuration. Each domain will have a bucket created for it, but may have mulitple aliases pointing to the same bucket.
   hosted_domains = [
     {
       domain : local.domain_name,

--- a/templates/terraform/environments/prod/main.tf
+++ b/templates/terraform/environments/prod/main.tf
@@ -129,4 +129,5 @@ module "prod" {
   ]
 
   user_role_mapping = data.terraform_remote_state.shared.outputs.user_role_mapping
+  ci_user_name      = data.terraform_remote_state.shared.outputs.ci_user_name
 }

--- a/templates/terraform/environments/prod/user_access.tf
+++ b/templates/terraform/environments/prod/user_access.tf
@@ -185,7 +185,8 @@ locals {
       api_groups = ["*"]
       resources = ["deployments", "configmaps", "pods", "pods/exec", "pods/log", "pods/status", "pods/portforward",
         "jobs", "cronjobs", "secrets", "services", "daemonsets", "endpoints", "namespaces", "events", "ingresses",
-        "horizontalpodautoscalers", "horizontalpodautoscalers/status"
+        "horizontalpodautoscalers", "horizontalpodautoscalers/status",
+        "poddisruptionbudgets"
       ]
     }
   ]
@@ -197,7 +198,8 @@ locals {
       api_groups = ["*"]
       resources = ["deployments", "configmaps", "pods", "pods/log", "pods/status",
         "jobs", "cronjobs", "services", "daemonsets", "endpoints", "namespaces", "events", "ingresses",
-        "horizontalpodautoscalers", "horizontalpodautoscalers/status"
+        "horizontalpodautoscalers", "horizontalpodautoscalers/status",
+        "poddisruptionbudgets"
       ]
     },
     {

--- a/templates/terraform/environments/prod/user_access.tf
+++ b/templates/terraform/environments/prod/user_access.tf
@@ -181,7 +181,7 @@ locals {
   # define Kubernetes policy for operator
   k8s_operator_access = [
     {
-      verbs      = ["exec", "create", "list", "get", "delete", "patch", "update"]
+      verbs      = ["exec", "create", "list", "get", "delete", "patch", "update", "watch"]
       api_groups = ["*"]
       resources = ["deployments", "configmaps", "pods", "pods/exec", "pods/log", "pods/status", "pods/portforward",
         "jobs", "cronjobs", "secrets", "services", "daemonsets", "endpoints", "namespaces", "events", "ingresses",
@@ -193,12 +193,17 @@ locals {
   # define Kubernetes policy for deployer
   k8s_deployer_access = [
     {
-      verbs      = ["exec", "create", "list", "get", "delete", "patch", "update"]
+      verbs      = ["create", "list", "get", "delete", "patch", "update", "watch"]
       api_groups = ["*"]
-      resources = ["deployments", "configmaps", "pods", "pods/exec", "pods/log", "pods/status", "pods/portforward",
-        "jobs", "cronjobs", "secrets", "services", "daemonsets", "endpoints", "namespaces", "events", "ingresses",
+      resources = ["deployments", "configmaps", "pods", "pods/log", "pods/status",
+        "jobs", "cronjobs", "services", "daemonsets", "endpoints", "namespaces", "events", "ingresses",
         "horizontalpodautoscalers", "horizontalpodautoscalers/status"
       ]
+    },
+    {
+      verbs      = ["create", "delete", "patch", "update"]
+      api_groups = ["*"]
+      resources  = ["secrets"]
     }
   ]
 }

--- a/templates/terraform/environments/prod/user_access.tf
+++ b/templates/terraform/environments/prod/user_access.tf
@@ -190,12 +190,15 @@ locals {
     }
   ]
 
-  # define Kubernetes policy for deployer: To Be Refined later
+  # define Kubernetes policy for deployer
   k8s_deployer_access = [
     {
-      verbs      = ["*"]
+      verbs      = ["exec", "create", "list", "get", "delete", "patch", "update"]
       api_groups = ["*"]
-      resources  = ["*"]
+      resources = ["deployments", "configmaps", "pods", "pods/exec", "pods/log", "pods/status", "pods/portforward",
+        "jobs", "cronjobs", "secrets", "services", "daemonsets", "endpoints", "namespaces", "events", "ingresses",
+        "horizontalpodautoscalers", "horizontalpodautoscalers/status"
+      ]
     }
   ]
 }

--- a/templates/terraform/environments/prod/user_access.tf
+++ b/templates/terraform/environments/prod/user_access.tf
@@ -175,7 +175,6 @@ locals {
       resources  = ["deployments", "configmaps", "pods", "services", "endpoints"]
     }
   ]
-  k8s_developer_groups = ["${local.project}-kubernetes-developer-prod"]
 
   # define Kubernetes policy for operator
   k8s_operator_access = [
@@ -185,7 +184,6 @@ locals {
       resources  = ["deployments", "configmaps", "pods", "secrets", "services", "endpoints"]
     }
   ]
-  k8s_operator_groups = ["${local.project}-kubernetes-operator-prod"]
 
   # define Kubernetes policy for deployer: To Be Refined later
   k8s_deployer_access = [
@@ -195,5 +193,4 @@ locals {
       resources  = ["deployments", "configmaps", "pods", "secrets", "services", "endpoints"]
     }
   ]
-  k8s_deployer_groups = ["system:master"]
 }

--- a/templates/terraform/environments/prod/user_access.tf
+++ b/templates/terraform/environments/prod/user_access.tf
@@ -86,6 +86,80 @@ data "aws_iam_policy_document" "operator_access" {
   }
 }
 
+# define AWS policy documents for deployer
+locals {
+  non_upload_buckets = [for p in module.prod.s3_hosting : p if ! p.cf_signing_enabled]
+}
+
+data "aws_iam_policy_document" "deployer_access" {
+  # deploy_assets_policy - Allow the deployers read/write access to the frontend assets bucket and CF invalidations
+  statement {
+    actions = [
+      "s3:ListBucket",
+    ]
+
+    resources = module.prod.s3_hosting[*].bucket_arn
+  }
+
+  statement {
+    actions = [
+      "s3:*Object",
+      "s3:GetBucketLocation",
+    ]
+
+    resources = formatlist("%s/*", local.non_upload_buckets[*].bucket_arn)
+  }
+
+  statement {
+    actions = [
+      "cloudfront:ListDistributions",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    actions = [
+      "cloudfront:CreateInvalidation",
+    ]
+    resources = formatlist("arn:aws:cloudfront::%s:distribution/%s", local.account_id, module.prod.s3_hosting[*].cloudfront_distribution_id)
+  }
+
+  # EKS - Allow the CI user to list and describe clusters
+  statement {
+    actions = [
+      "eks:ListUpdates",
+      "eks:ListClusters",
+      "eks:DescribeUpdate",
+      "eks:DescribeCluster",
+    ]
+
+    resources = ["*"]
+  }
+
+  # ECR - Allow the deployers to manage ECR
+  statement {
+    effect = "Allow"
+    actions = [
+      "ecr:GetAuthorizationToken",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:GetRepositoryPolicy",
+      "ecr:DescribeRepositories",
+      "ecr:ListImages",
+      "ecr:DescribeImages",
+      "ecr:BatchGetImage",
+      "ecr:GetLifecyclePolicy",
+      "ecr:GetLifecyclePolicyPreview",
+      "ecr:ListTagsForResource",
+      "ecr:DescribeImageScanFindings",
+      "ecr:InitiateLayerUpload",
+      "ecr:UploadLayerPart",
+      "ecr:CompleteLayerUpload",
+    ]
+    resources = ["*"]
+  }
+}
 
 
 locals {
@@ -101,6 +175,7 @@ locals {
       resources  = ["deployments", "configmaps", "pods", "services", "endpoints"]
     }
   ]
+  k8s_developer_groups = ["${local.project}-kubernetes-developer-prod"]
 
   # define Kubernetes policy for operator
   k8s_operator_access = [
@@ -110,4 +185,15 @@ locals {
       resources  = ["deployments", "configmaps", "pods", "secrets", "services", "endpoints"]
     }
   ]
+  k8s_operator_groups = ["${local.project}-kubernetes-operator-prod"]
+
+  # define Kubernetes policy for deployer: To Be Refined later
+  k8s_deployer_access = [
+    {
+      verbs      = ["exec", "create", "list", "get", "delete", "patch", "update"]
+      api_groups = [""]
+      resources  = ["deployments", "configmaps", "pods", "secrets", "services", "endpoints"]
+    }
+  ]
+  k8s_deployer_groups = ["system:master"]
 }

--- a/templates/terraform/environments/prod/user_access.tf
+++ b/templates/terraform/environments/prod/user_access.tf
@@ -188,9 +188,9 @@ locals {
   # define Kubernetes policy for deployer: To Be Refined later
   k8s_deployer_access = [
     {
-      verbs      = ["exec", "create", "list", "get", "delete", "patch", "update"]
-      api_groups = [""]
-      resources  = ["deployments", "configmaps", "pods", "secrets", "services", "endpoints"]
+      verbs      = ["*"]
+      api_groups = ["*"]
+      resources  = ["*"]
     }
   ]
 }

--- a/templates/terraform/environments/shared/main.tf
+++ b/templates/terraform/environments/shared/main.tf
@@ -33,14 +33,16 @@ locals {
           ]
           global_roles       = []
           create_access_keys = true
-    #    }, {
+    #    },
+    #    {
     #      name  = "dev1"
     #      roles = [
     #        { name = "developer", environments = ["stage", "prod"] }
     #      ]
     #      global_roles       = ["mfa-required", "console-allowed"]
     #      create_access_keys = false
-    #    }, {
+    #    },
+    #    {
     #      name  = "devops1"
     #      roles = [
     #        { name = "developer", environments = ["stage", "prod"] },
@@ -48,7 +50,8 @@ locals {
     #      ]
     #      global_roles       = ["mfa-required", "console-allowed"]
     #      create_access_keys = false
-    #    }, {
+    #    },
+    #    {
     #      name  = "operator1"
     #      roles = [
     #        { name = "operator", environments = ["stage", "prod"] }

--- a/templates/terraform/environments/shared/main.tf
+++ b/templates/terraform/environments/shared/main.tf
@@ -77,7 +77,6 @@ resource "aws_iam_group_membership" "mfa_required_group" {
 
   users = [
     for user in local.users : user.name if contains(user.global_roles, "mfa-required")
-
   ]
 
   group = aws_iam_group.mfa_required.name
@@ -89,7 +88,7 @@ resource "aws_iam_group_membership" "console_allowed_group" {
   name = "console-allowed"
 
   users = [
-    for user in aws_iam_user.access_user : user.name
+    for user in local.users : user.name if contains(user.global_roles, "console-allowed")
   ]
 
   group = aws_iam_group.console_allowed.name

--- a/templates/terraform/environments/shared/main.tf
+++ b/templates/terraform/environments/shared/main.tf
@@ -142,12 +142,6 @@ output "user_role_mapping" {
   ]
 }
 
-output "ci_users" {
-  value = [
-    for u in local.users: u.name if contains(u.roles.*.name, "deployer")
-  ]
-}
-
 output "cloudtrail_bucket_id" {
   value = module.cloudtrail.cloudtrail_bucket_id
 }

--- a/templates/terraform/environments/shared/main.tf
+++ b/templates/terraform/environments/shared/main.tf
@@ -10,9 +10,10 @@ terraform {
 }
 
 locals {
-  project    = "<% .Name %>"
-  region     = "<% index .Params `region` %>"
-  account_id = "<% index .Params `accountId` %>"
+  project     = "<% .Name %>"
+  region      = "<% index .Params `region` %>"
+  account_id  = "<% index .Params `accountId` %>"
+  random_seed = "<% index .Params `randomSeed` %>"
 }
 
 provider "aws" {
@@ -24,27 +25,40 @@ provider "aws" {
 locals {
   # Users configuration
   users = [
-    #    {
+        {
+          name  = "${local.project}-ci-user-shared"
+          roles = [
+            { name = "deployer", environments = ["stage", "prod"] }
+          ]
+          global_roles       = ["console-allowed"]
+          create_access_keys = true
+    #    }, {
     #      name  = "dev1"
     #      roles = [
     #        { name = "developer", environments = ["stage", "prod"] }
     #      ]
+    #      global_roles       = ["mfa-required", "console-allowed"]
+    #      create_access_keys = false
     #    }, {
     #      name  = "devops1"
     #      roles = [
     #        { name = "developer", environments = ["stage", "prod"] },
     #        { name = "operator",  environments = ["stage"] }
     #      ]
+    #      global_roles       = ["mfa-required", "console-allowed"]
+    #      create_access_keys = false
     #    }, {
     #      name  = "operator1"
     #      roles = [
     #        { name = "operator", environments = ["stage", "prod"] }
     #      ]
-    #    },
+    #      global_roles       = ["mfa-required", "console-allowed"]
+    #      create_access_keys = false
+        },
   ]
 }
 
-## Create users
+# Create users
 resource "aws_iam_user" "access_user" {
   for_each = { for u in local.users : u.name => u.roles }
 
@@ -55,16 +69,20 @@ resource "aws_iam_user" "access_user" {
   }
 }
 
-# This is recommended to be enabled, ensuring that all users must use MFA
-# https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#securityhub-cis-controls-1.2
+## assign users to MFA-Required group
+## This is recommended to be enabled, ensuring that all users must use MFA
+## https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#securityhub-cis-controls-1.2
 resource "aws_iam_group_membership" "mfa_required_group" {
   name = "mfa-required"
 
   users = [
-    for user in aws_iam_user.access_user : user.name
+    for user in local.users : user.name if contains(user.global_roles, "mfa-required")
+
   ]
 
   group = aws_iam_group.mfa_required.name
+
+  depends_on = [ aws_iam_user.access_user ]
 }
 
 resource "aws_iam_group_membership" "console_allowed_group" {
@@ -75,6 +93,29 @@ resource "aws_iam_group_membership" "console_allowed_group" {
   ]
 
   group = aws_iam_group.console_allowed.name
+
+  depends_on = [ aws_iam_user.access_user ]
+}
+
+## Create access/secret key pair and save to secret manager
+resource "aws_iam_access_key" "access_user" {
+  for_each = { for u in local.users : u.name => u.roles if u.create_access_keys}
+
+  user = aws_iam_user.access_user[each.key].name
+
+  depends_on = [ aws_iam_user.access_user ]
+}
+
+module "secret_keys" {
+  source  = "commitdev/zero/aws//modules/secret"
+  version = "0.0.2"
+
+  for_each = aws_iam_access_key.access_user
+
+  name   = "${each.value.user}-aws-keys${local.random_seed}"
+  type   = "map"
+  values = map("access_key_id", each.value.id, "secret_key", each.value.secret)
+  tags   = map("project", local.project)
 }
 
 # Enable AWS CloudTrail to help you audit governance, compliance, and operational risk of your AWS account, with logs stored in S3 bucket.
@@ -93,7 +134,18 @@ output "iam_users" {
 }
 
 output "user_role_mapping" {
-  value = local.users
+  value = [
+    for u in local.users: {
+      name  = u.name
+      roles = u.roles
+    }
+  ]
+}
+
+output "ci_users" {
+  value = [
+    for u in local.users: u.name if contains(u.roles.*.name, "deployer")
+  ]
 }
 
 output "cloudtrail_bucket_id" {

--- a/templates/terraform/environments/shared/main.tf
+++ b/templates/terraform/environments/shared/main.tf
@@ -24,13 +24,14 @@ provider "aws" {
 # Instantiate the environment
 locals {
   # Users configuration
+  ci_user_name = "${local.project}-ci-user"
   users = [
         {
-          name  = "${local.project}-ci-user"
+          name  = local.ci_user_name
           roles = [
             { name = "deployer", environments = ["stage", "prod"] }
           ]
-          global_roles       = ["console-allowed"]
+          global_roles       = []
           create_access_keys = true
     #    }, {
     #      name  = "dev1"
@@ -140,6 +141,10 @@ output "user_role_mapping" {
       roles = u.roles
     }
   ]
+}
+
+output "ci_user_name" {
+  value = local.ci_user_name
 }
 
 output "cloudtrail_bucket_id" {

--- a/templates/terraform/environments/shared/main.tf
+++ b/templates/terraform/environments/shared/main.tf
@@ -128,6 +128,7 @@ module "cloudtrail" {
   include_global_service_events = false
 }
 
+# Outputs
 output "iam_users" {
   value = aws_iam_user.access_user
 }

--- a/templates/terraform/environments/shared/main.tf
+++ b/templates/terraform/environments/shared/main.tf
@@ -26,7 +26,7 @@ locals {
   # Users configuration
   users = [
         {
-          name  = "${local.project}-ci-user-shared"
+          name  = "${local.project}-ci-user"
           roles = [
             { name = "deployer", environments = ["stage", "prod"] }
           ]

--- a/templates/terraform/environments/stage/main.tf
+++ b/templates/terraform/environments/stage/main.tf
@@ -119,22 +119,18 @@ module "stage" {
       name         = "developer"
       aws_policy   = data.aws_iam_policy_document.developer_access.json
       k8s_policies = local.k8s_developer_access
-      k8s_groups   = local.k8s_developer_groups
     },
     {
       name         = "operator"
       aws_policy   = data.aws_iam_policy_document.operator_access.json
       k8s_policies = local.k8s_operator_access
-      k8s_groups   = local.k8s_operator_groups
     },
     {
       name         = "deployer"
       aws_policy   = data.aws_iam_policy_document.deployer_access.json
       k8s_policies = local.k8s_deployer_access
-      k8s_groups   = local.k8s_deployer_groups
     }
   ]
 
   user_role_mapping = data.terraform_remote_state.shared.outputs.user_role_mapping
-  ci_users          = data.terraform_remote_state.shared.outputs.ci_users
 }

--- a/templates/terraform/environments/stage/main.tf
+++ b/templates/terraform/environments/stage/main.tf
@@ -133,4 +133,5 @@ module "stage" {
   ]
 
   user_role_mapping = data.terraform_remote_state.shared.outputs.user_role_mapping
+  ci_user_name      = data.terraform_remote_state.shared.outputs.ci_user_name
 }

--- a/templates/terraform/environments/stage/main.tf
+++ b/templates/terraform/environments/stage/main.tf
@@ -21,6 +21,7 @@ locals {
   region      = "<% index .Params `region` %>"
   account_id  = "<% index .Params `accountId` %>"
   domain_name = "<% index .Params `stagingHostRoot` %>"
+  random_seed = "<% index .Params `randomSeed` %>"
 }
 
 provider "aws" {
@@ -49,7 +50,7 @@ module "stage" {
   project             = local.project
   region              = local.region
   allowed_account_ids = [local.account_id]
-  random_seed         = "<% index .Params `randomSeed` %>"
+  random_seed         = local.random_seed
 
   # ECR configuration
   ecr_repositories = [ local.project ]
@@ -118,13 +119,22 @@ module "stage" {
       name         = "developer"
       aws_policy   = data.aws_iam_policy_document.developer_access.json
       k8s_policies = local.k8s_developer_access
+      k8s_groups   = local.k8s_developer_groups
     },
     {
       name         = "operator"
       aws_policy   = data.aws_iam_policy_document.operator_access.json
       k8s_policies = local.k8s_operator_access
+      k8s_groups   = local.k8s_operator_groups
+    },
+    {
+      name         = "deployer"
+      aws_policy   = data.aws_iam_policy_document.deployer_access.json
+      k8s_policies = local.k8s_deployer_access
+      k8s_groups   = local.k8s_deployer_groups
     }
   ]
 
   user_role_mapping = data.terraform_remote_state.shared.outputs.user_role_mapping
+  ci_users          = data.terraform_remote_state.shared.outputs.ci_users
 }

--- a/templates/terraform/environments/stage/user_access.tf
+++ b/templates/terraform/environments/stage/user_access.tf
@@ -175,7 +175,6 @@ locals {
       resources  = ["deployments", "configmaps", "pods", "services", "endpoints"]
     }
   ]
-  k8s_developer_groups = ["${local.project}-kubernetes-developer-stage"]
 
   # define Kubernetes policy for operator
   k8s_operator_access = [
@@ -185,7 +184,6 @@ locals {
       resources  = ["deployments", "configmaps", "pods", "secrets", "services", "endpoints"]
     }
   ]
-  k8s_operator_groups = ["${local.project}-kubernetes-operator-stage"]
 
   # define Kubernetes policy for deployer: To Be Refined later
   k8s_deployer_access = [
@@ -195,5 +193,4 @@ locals {
       resources  = ["deployments", "configmaps", "pods", "secrets", "services", "endpoints"]
     }
   ]
-  k8s_deployer_groups = ["system:master"]
 }

--- a/templates/terraform/environments/stage/user_access.tf
+++ b/templates/terraform/environments/stage/user_access.tf
@@ -185,7 +185,8 @@ locals {
       api_groups = ["*"]
       resources = ["deployments", "configmaps", "pods", "pods/exec", "pods/log", "pods/status", "pods/portforward",
         "jobs", "cronjobs", "secrets", "services", "daemonsets", "endpoints", "namespaces", "events", "ingresses",
-        "horizontalpodautoscalers", "horizontalpodautoscalers/status"
+        "horizontalpodautoscalers", "horizontalpodautoscalers/status",
+        "poddisruptionbudgets"
       ]
     }
   ]
@@ -197,7 +198,8 @@ locals {
       api_groups = ["*"]
       resources = ["deployments", "configmaps", "pods", "pods/log", "pods/status",
         "jobs", "cronjobs", "services", "daemonsets", "endpoints", "namespaces", "events", "ingresses",
-        "horizontalpodautoscalers", "horizontalpodautoscalers/status"
+        "horizontalpodautoscalers", "horizontalpodautoscalers/status",
+        "poddisruptionbudgets"
       ]
     },
     {

--- a/templates/terraform/environments/stage/user_access.tf
+++ b/templates/terraform/environments/stage/user_access.tf
@@ -181,7 +181,7 @@ locals {
   # define Kubernetes policy for operator
   k8s_operator_access = [
     {
-      verbs      = ["exec", "create", "list", "get", "delete", "patch", "update"]
+      verbs      = ["exec", "create", "list", "get", "delete", "patch", "update", "watch"]
       api_groups = ["*"]
       resources = ["deployments", "configmaps", "pods", "pods/exec", "pods/log", "pods/status", "pods/portforward",
         "jobs", "cronjobs", "secrets", "services", "daemonsets", "endpoints", "namespaces", "events", "ingresses",
@@ -193,12 +193,17 @@ locals {
   # define Kubernetes policy for deployer
   k8s_deployer_access = [
     {
-      verbs      = ["exec", "create", "list", "get", "delete", "patch", "update"]
+      verbs      = ["create", "list", "get", "delete", "patch", "update", "watch"]
       api_groups = ["*"]
-      resources = ["deployments", "configmaps", "pods", "pods/exec", "pods/log", "pods/status", "pods/portforward",
-        "jobs", "cronjobs", "secrets", "services", "daemonsets", "endpoints", "namespaces", "events", "ingresses",
+      resources = ["deployments", "configmaps", "pods", "pods/log", "pods/status",
+        "jobs", "cronjobs", "services", "daemonsets", "endpoints", "namespaces", "events", "ingresses",
         "horizontalpodautoscalers", "horizontalpodautoscalers/status"
       ]
+    },
+    {
+      verbs      = ["create", "delete", "patch", "update"]
+      api_groups = ["*"]
+      resources  = ["secrets"]
     }
   ]
 }

--- a/templates/terraform/environments/stage/user_access.tf
+++ b/templates/terraform/environments/stage/user_access.tf
@@ -190,12 +190,15 @@ locals {
     }
   ]
 
-  # define Kubernetes policy for deployer: To Be Refined later
+  # define Kubernetes policy for deployer
   k8s_deployer_access = [
     {
-      verbs      = ["*"]
+      verbs      = ["exec", "create", "list", "get", "delete", "patch", "update"]
       api_groups = ["*"]
-      resources  = ["*"]
+      resources = ["deployments", "configmaps", "pods", "pods/exec", "pods/log", "pods/status", "pods/portforward",
+        "jobs", "cronjobs", "secrets", "services", "daemonsets", "endpoints", "namespaces", "events", "ingresses",
+        "horizontalpodautoscalers", "horizontalpodautoscalers/status"
+      ]
     }
   ]
 }

--- a/templates/terraform/environments/stage/user_access.tf
+++ b/templates/terraform/environments/stage/user_access.tf
@@ -188,9 +188,9 @@ locals {
   # define Kubernetes policy for deployer: To Be Refined later
   k8s_deployer_access = [
     {
-      verbs      = ["exec", "create", "list", "get", "delete", "patch", "update"]
-      api_groups = [""]
-      resources  = ["deployments", "configmaps", "pods", "secrets", "services", "endpoints"]
+      verbs      = ["*"]
+      api_groups = ["*"]
+      resources  = ["*"]
     }
   ]
 }

--- a/templates/terraform/modules/environment/iam.tf
+++ b/templates/terraform/modules/environment/iam.tf
@@ -2,10 +2,6 @@
 #
 # Kubernetes admin role
 
-locals {
-  non_upload_buckets = [for bucket in module.s3_hosting : bucket if ! bucket.cf_signing_enabled]
-}
-
 # Create KubernetesAdmin role for aws-iam-authenticator
 resource "aws_iam_role" "kubernetes_admin_role" {
   name               = "${var.project}-kubernetes-admin-${var.environment}"
@@ -23,94 +19,4 @@ data "aws_iam_policy_document" "assumerole_root_policy" {
       identifiers = [data.aws_caller_identity.current.account_id]
     }
   }
-
-  # Allow the CI user to assume this role
-  statement {
-    actions = ["sts:AssumeRole"]
-
-    principals {
-      type        = "AWS"
-      identifiers = [data.aws_iam_user.ci_user.arn]
-    }
-  }
-}
-
-
-#
-# CI User
-
-resource "aws_iam_user_policy_attachment" "circleci_ecr_access" {
-  user       = data.aws_iam_user.ci_user.user_name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser"
-}
-
-# Allow the CI user to list and describe clusters
-data "aws_iam_policy_document" "eks_list_and_describe" {
-  statement {
-    actions = [
-      "eks:ListUpdates",
-      "eks:ListClusters",
-      "eks:DescribeUpdate",
-      "eks:DescribeCluster",
-    ]
-
-    resources = ["*"]
-  }
-}
-
-resource "aws_iam_policy" "eks_list_and_describe_policy" {
-  name_prefix = "eks-list-and-describe"
-  description = "Policy to allow listing and describing EKS clusters for ${var.project} ${var.environment}"
-  policy      = data.aws_iam_policy_document.eks_list_and_describe.json
-}
-
-resource "aws_iam_user_policy_attachment" "ci_user_list_and_describe_policy" {
-  user       = data.aws_iam_user.ci_user.user_name
-  policy_arn = aws_iam_policy.eks_list_and_describe_policy.arn
-}
-
-# Allow the CI user read/write access to the frontend assets bucket and CF invalidations
-data "aws_iam_policy_document" "deploy_assets_policy" {
-  statement {
-    actions = [
-      "s3:ListBucket",
-    ]
-
-    resources = module.s3_hosting[*].bucket_arn
-  }
-
-  statement {
-    actions = [
-      "s3:*Object",
-      "s3:GetBucketLocation",
-    ]
-
-    resources = formatlist("%s/*", local.non_upload_buckets[*].bucket_arn)
-  }
-
-  statement {
-    actions = [
-      "cloudfront:ListDistributions",
-    ]
-
-    resources = ["*"]
-  }
-
-  statement {
-    actions = [
-      "cloudfront:CreateInvalidation",
-    ]
-    resources = formatlist("arn:aws:cloudfront::%s:distribution/%s", data.aws_caller_identity.current.account_id, module.s3_hosting[*].cloudfront_distribution_id)
-  }
-}
-
-resource "aws_iam_policy" "deploy_assets_policy" {
-  name_prefix = "ci-deploy-assets"
-  description = "Policy to allow a CI user to deploy assets for ${var.project} ${var.environment}"
-  policy      = data.aws_iam_policy_document.deploy_assets_policy.json
-}
-
-resource "aws_iam_user_policy_attachment" "ci_s3_policy" {
-  user       = data.aws_iam_user.ci_user.user_name
-  policy_arn = aws_iam_policy.deploy_assets_policy.arn
 }

--- a/templates/terraform/modules/environment/main.tf
+++ b/templates/terraform/modules/environment/main.tf
@@ -21,7 +21,7 @@ locals {
     for m in module.user_access.eks_iam_role_mapping : {
       arn    = m.arn
       name   = m.name
-      groups = length(regexall(".*deployer.*", m.name)) > 0 ? [ "system:master" ] : [ m.name ]
+      groups = [ m.name ]
     }
   ]
 }

--- a/templates/terraform/modules/environment/main.tf
+++ b/templates/terraform/modules/environment/main.tf
@@ -13,11 +13,11 @@ locals {
     }
   ]
 
-  eks_iam_role_mapping = [
-    for m in module.user_access.eks_iam_role_mapping : {
-      arn    = m.arn
-      name   = m.name
-      groups = [ m.name ]
+  kubernetes_iam_role_mapping = [
+    for r in module.user_access.iam_assumerole_arns : {
+      iam_role_arn  = r.arn
+      k8s_role_name = r.name
+      k8s_groups    = [ r.name ]
     }
   ]
 }
@@ -64,7 +64,7 @@ module "eks" {
   worker_asg_max_size  = var.eks_worker_asg_max_size
   worker_ami           = var.eks_worker_ami # EKS-Optimized AMI for your region: https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html
 
-  iam_role_mapping = local.eks_iam_role_mapping
+  iam_role_mapping = local.kubernetes_iam_role_mapping
 }
 
 

--- a/templates/terraform/modules/environment/main.tf
+++ b/templates/terraform/modules/environment/main.tf
@@ -14,7 +14,7 @@ locals {
   ]
 
   kubernetes_iam_role_mapping = [
-    for r in module.user_access.iam_assumerole_arns : {
+    for r in module.user_access.eks_iam_role_mapping : {
       iam_role_arn  = r.arn
       k8s_role_name = r.name
       k8s_groups    = [ r.name ]
@@ -44,7 +44,7 @@ data "aws_caller_identity" "current" {}
 # Provision the EKS cluster
 module "eks" {
   source  = "commitdev/zero/aws//modules/eks"
-  version = "0.1.2"
+  version = "0.1.12"
   providers = {
     aws = aws.for_eks
   }
@@ -108,7 +108,7 @@ module "s3_hosting" {
 
 module "db" {
   source  = "commitdev/zero/aws//modules/database"
-  version = "0.1.2"
+  version = "0.1.12"
 
   project                   = var.project
   environment               = var.environment
@@ -158,7 +158,7 @@ module "sendgrid" {
 
 module "user_access" {
   source  = "commitdev/zero/aws//modules/user_access"
-  version = "0.1.8"
+  version = "0.1.12"
 
   project     = var.project
   environment = var.environment

--- a/templates/terraform/modules/environment/main.tf
+++ b/templates/terraform/modules/environment/main.tf
@@ -169,6 +169,7 @@ module "user_access" {
 
 
 output "s3_hosting" {
+  description = "used by access policy for s3 hosting bucket"
   value = [
     for p in module.s3_hosting : {
       cloudfront_distribution_id = p.cloudfront_distribution_id

--- a/templates/terraform/modules/environment/main.tf
+++ b/templates/terraform/modules/environment/main.tf
@@ -27,9 +27,9 @@ locals {
 }
 
 data "aws_iam_user" "ci_user" {
-  count = length(var.ci_users)
+  count = length(local.ci_users)
 
-  user_name = var.ci_users[count.index]
+  user_name = local.ci_users[count.index]
 }
 
 module "vpc" {

--- a/templates/terraform/modules/environment/main.tf
+++ b/templates/terraform/modules/environment/main.tf
@@ -13,10 +13,6 @@ locals {
     }
   ]
 
-  ci_users = [
-    for u in local.users: u.name if contains(u.roles, "deployer")
-  ]
-
   eks_iam_role_mapping = [
     for m in module.user_access.eks_iam_role_mapping : {
       arn    = m.arn
@@ -27,9 +23,7 @@ locals {
 }
 
 data "aws_iam_user" "ci_user" {
-  count = length(local.ci_users)
-
-  user_name = local.ci_users[count.index]
+  user_name = var.ci_user_name
 }
 
 module "vpc" {
@@ -132,7 +126,7 @@ module "ecr" {
 
   environment      = var.environment
   ecr_repositories = var.ecr_repositories
-  ecr_principals   = data.aws_iam_user.ci_user.*.arn
+  ecr_principals   = [data.aws_iam_user.ci_user.arn]
 }
 
 module "logging" {

--- a/templates/terraform/modules/environment/variables.tf
+++ b/templates/terraform/modules/environment/variables.tf
@@ -149,7 +149,6 @@ variable "roles" {
     name         = string
     aws_policy   = string
     k8s_policies = list(map(list(string)))
-    k8s_groups   = list(string)
   }))
   description = "Role list with policies"
 }
@@ -163,9 +162,4 @@ variable "user_role_mapping" {
     }))
   }))
   description = "User-Roles mapping with environment"
-}
-
-variable "ci_users" {
-  description = "CI Users"
-  type        = list(string)
 }

--- a/templates/terraform/modules/environment/variables.tf
+++ b/templates/terraform/modules/environment/variables.tf
@@ -149,6 +149,7 @@ variable "roles" {
     name         = string
     aws_policy   = string
     k8s_policies = list(map(list(string)))
+    k8s_groups   = list(string)
   }))
   description = "Role list with policies"
 }
@@ -162,4 +163,9 @@ variable "user_role_mapping" {
     }))
   }))
   description = "User-Roles mapping with environment"
+}
+
+variable "ci_users" {
+  description = "CI Users"
+  type        = list(string)
 }

--- a/templates/terraform/modules/environment/variables.tf
+++ b/templates/terraform/modules/environment/variables.tf
@@ -163,3 +163,8 @@ variable "user_role_mapping" {
   }))
   description = "User-Roles mapping with environment"
 }
+
+variable "ci_user_name" {
+  type        = string
+  description = "CI user name" 
+}


### PR DESCRIPTION
Changes:
- move ci-user creation and access key handling out of `bootstrap` to `shared` and assign to new role `deployer`
- added new parameter `create_access_keys` etc. for roles
- set `deploye`r policy same as `operator`
- not allow ci-user to access console