### PR TITLE
fix for_each with local variable for access_key creation

### DIFF
--- a/templates/terraform/environments/shared/main.tf
+++ b/templates/terraform/environments/shared/main.tf
@@ -113,12 +113,14 @@ module "secret_keys" {
   source  = "commitdev/zero/aws//modules/secret"
   version = "0.0.2"
 
-  for_each = aws_iam_access_key.access_user
+  for_each = { for u in local.users : u.name => u.roles if u.create_access_keys}
 
-  name   = "${each.value.user}-aws-keys${local.random_seed}"
+  name   = "${each.key}-aws-keys${local.random_seed}"
   type   = "map"
-  values = map("access_key_id", each.value.id, "secret_key", each.value.secret)
+  values = map("access_key_id", aws_iam_access_key.access_user[each.key].id, "secret_key", aws_iam_access_key.access_user[each.key].secret)
   tags   = map("project", local.project)
+
+  depends_on = [ aws_iam_access_key.access_user ]
 }
 
 # Enable AWS CloudTrail to help you audit governance, compliance, and operational risk of your AWS account, with logs stored in S3 bucket.


### PR DESCRIPTION
fix for_each with local variable, failed when no state for reference (eg. initial setup)

Reproduction:
- new environment, make apply-shared-env, or
- under environments/shared, run `terraform plan`

Investigation:
- run `terraform state list`, show error:
``` 
state file was found!

State management commands require a state file. Run this command
in a directory where Terraform has been run or use the -state flag
to point the command to a specific state location.
```
- delete .terraform, run `terraform init`, do `terraform plan` again, same error
which means at this moment, TF has no way to refer the state.

Solution:
- use local variables {} with for_each