### PR TITLE
helm provider have same kubernetes config setup

### DIFF
--- a/templates/kubernetes/terraform/modules/kubernetes/provider.tf
+++ b/templates/kubernetes/terraform/modules/kubernetes/provider.tf
@@ -36,3 +36,11 @@ provider "kubernetes" {
   load_config_file       = false
   version                = "~> 1.11"
 }
+
+provider "helm" {
+  kubernetes {
+    host                   = data.aws_eks_cluster.cluster.endpoint
+    cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+    token                  = data.aws_eks_cluster_auth.cluster.token
+  }
+}

--- a/templates/kubernetes/terraform/modules/kubernetes/user_auth.tf
+++ b/templates/kubernetes/terraform/modules/kubernetes/user_auth.tf
@@ -214,6 +214,7 @@ resource "helm_release" "kratos" {
 }
 
 data "template_file" "oathkeeper_kratos_proxy_rules" {
+  count = var.auth_enabled ? 1 : 0
   template = file("${path.module}/files/oathkeeper_kratos_proxy_rules.yaml.tpl")
   vars = {
     backend_service_domain    = var.backend_service_domain
@@ -223,12 +224,13 @@ data "template_file" "oathkeeper_kratos_proxy_rules" {
 }
 
 resource "null_resource" "oathkeeper_kratos_proxy_rules" {
+  count = var.auth_enabled ? 1 : 0
   triggers = {
-    manifest_sha1 = sha1(data.template_file.oathkeeper_kratos_proxy_rules.rendered)
+    manifest_sha1 = sha1(data.template_file.oathkeeper_kratos_proxy_rules[0].rendered)
   }
   # local exec call requires kubeconfig to be updated
   provisioner "local-exec" {
-    command = "kubectl apply -f - <<EOF\n${data.template_file.oathkeeper_kratos_proxy_rules.rendered}\nEOF"
+    command = "kubectl apply -f - <<EOF\n${data.template_file.oathkeeper_kratos_proxy_rules[0].rendered}\nEOF"
   }
   depends_on = [helm_release.oathkeeper]
 }


### PR DESCRIPTION
Somehow the helm provider does not by default use kubernetes provider
configured, redundant k8s config for the helm-provider to ensure
helm can find the target cluster