### PR TITLE
fix: Bump logging module version

### DIFF
--- a/templates/terraform/modules/environment/main.tf
+++ b/templates/terraform/modules/environment/main.tf
@@ -134,7 +134,7 @@ module "ecr" {
 
 module "logging" {
   source  = "commitdev/zero/aws//modules/logging"
-  version = "0.1.18"
+  version = "0.1.20"
 
   count = var.logging_type == "kibana" ? 1 : 0
 


### PR DESCRIPTION
Previous version included an unintended issue from a downstream module which was forcing the cluster to only allow HTTPS.