### PR TITLE
Bump nginx ingress version

### DIFF
--- a/templates/kubernetes/terraform/modules/kubernetes/main.tf
+++ b/templates/kubernetes/terraform/modules/kubernetes/main.tf
@@ -28,7 +28,7 @@ module "metrics_prometheus" {
 
 module "ingress" {
   source  = "commitdev/zero/aws//modules/kubernetes/ingress_nginx"
-  version = "0.2.0"
+  version = "0.2.1"
 
   replica_count  = var.nginx_ingress_replicas
   enable_metrics = var.metrics_type == "prometheus"

--- a/templates/kubernetes/terraform/modules/kubernetes/metrics/prometheus/files/prometheus_operator_helm_values.yml
+++ b/templates/kubernetes/terraform/modules/kubernetes/metrics/prometheus/files/prometheus_operator_helm_values.yml
@@ -142,21 +142,3 @@ prometheus:
     # Don't apply a selector when looking for service and pod monitors, just discover all of them
     serviceMonitorSelectorNilUsesHelmValues: false
     podMonitorSelectorNilUsesHelmValues: false
-
-
-  ## Additional ServiceMonitors to create
-  additionalServiceMonitors:
-    - name: "nginx-ingress-controller-metrics"
-
-      ## Label selector for services to which this ServiceMonitor applies
-      selector:
-        matchLabels:
-          app.kubernetes.io/name: ingress-nginx
-
-      namespaceSelector:
-        matchNames: [ ingress-nginx ]
-
-      ## Endpoints of the selected service to be monitored
-      endpoints:
-        - port: "metrics"
-          interval: 30s


### PR DESCRIPTION
Bump ingress version, remove the service monitor created by the prometheus setup. It's created by the helm chart in the ingress module now.
﻿
