### PR TITLE
Fix module to be compatible with zero v0.1.1

### DIFF
--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+# TODO: add checks to run pre-zero apply

--- a/zero-module.yml
+++ b/zero-module.yml
@@ -1,7 +1,9 @@
 name: zero-aws-eks-stack
 description: 'zero module for an AWS kubernetes stack on EKS'
 author: 'Commit'
-zeroVersion: '>= 0.1.0'
+zeroVersion: '>= 0.1.1'
+commands:
+  check: sh scripts/check.sh
 
 template:
   strictMode: true


### PR DESCRIPTION
Fixing eks stack does not fulfill the check step (neither has a check command nor `make check` target) 