### PR TITLE
fix: Pin the aws provider version for now due to a regression in newer versions, small docs fixes

### DIFF
--- a/doc-site/docs/components/kubernetes/external-secrets.md
+++ b/doc-site/docs/components/kubernetes/external-secrets.md
@@ -5,7 +5,7 @@ sidebar_position: 3
 ---
 
 ## Overview
-Kubernetes External Secrets allows you to use external secret management systems, like AWS Secrets Manager or HashiCorp Vault, to securely add secrets in Kubernetes. 
+Kubernetes External Secrets allows you to use external secret management systems, like AWS Secrets Manager or HashiCorp Vault, to securely add secrets in Kubernetes.
 
 ## How it works
 The project extends the Kubernetes API by adding an ExternalSecrets object using Custom Resource Definition and a controller to implement the behavior of the object itself.
@@ -16,7 +16,7 @@ An ExternalSecret declares how to fetch the secret data, while the controller co
 Along with the database credentials, any other secrets that need to be provided to the application can be managed in AWS Secrets Manager.
 Secrets have been created for each environment called `<project-name>/kubernetes/<environment>/<project-name>` which contain a list of environment variables that will be synced with the kubernetes secret in your namespace via a tool called [external-secrets](https://github.com/external-secrets/kubernetes-external-secrets)
 Any secrets managed by `external-secrets` will be synced to kubernetes every 15 seconds. Keep in mind that any changes must be made in Secrets Manager, as any that are made to the secret on the kubernetes side will be overwritten.
-You can see the `external-secrets` configuration in [kubernetes/overlays/staging/external-secret.yml](https://github.com/commitdev/zero-deployable-backend/blob/main/templates/kubernetes/overlays/staging/external-secret.yml) (this is the one for staging)
+You can see the `external-secrets` configuration in [kubernetes/overlays/staging/external-secret.yml](https://github.com/commitdev/zero-backend-go/blob/main/templates/kubernetes/overlays/staging/external-secret.yml) (this is the one for staging)
 
 To work with the secret in AWS you can use the web interface or the cli tool:
 ```

--- a/templates/kubernetes/terraform/modules/kubernetes/cache_service.tf
+++ b/templates/kubernetes/terraform/modules/kubernetes/cache_service.tf
@@ -17,7 +17,7 @@ locals {
 resource "kubernetes_service" "app_cache" {
   count = local.endpoint_address == "" ? 0 : 1
 
-  ## this should match the deployable backend's name/namespace
+  ## this should match the backend service's name/namespace
   metadata {
     namespace = kubernetes_namespace.app_namespace.metadata[0].name
     name      = "cache-${var.cache_store}"

--- a/templates/kubernetes/terraform/modules/kubernetes/database_service.tf
+++ b/templates/kubernetes/terraform/modules/kubernetes/database_service.tf
@@ -5,9 +5,9 @@ data "aws_db_instance" "database" {
 
 resource "kubernetes_service" "app_db" {
   count = var.create_database_service ? 1 : 0
-  ## this should match the deployable backend's name/namespace
+  ## this should match the backend service's name/namespace
   ## it uses this service to connect and create application user
-  ## https://github.com/commitdev/zero-deployable-backend/blob/b2cee21982b1e6a0ac9996e2a1bf214e5bf10ab5/db-ops/create-db-user.sh#L6
+  ## https://github.com/commitdev/zero-backend-go/blob/b2cee21982b1e6a0ac9996e2a1bf214e5bf10ab5/db-ops/create-db-user.sh#L6
   metadata {
     namespace = kubernetes_namespace.app_namespace.metadata[0].name
     name      = "database"

--- a/templates/terraform/environments/prod/main.tf
+++ b/templates/terraform/environments/prod/main.tf
@@ -11,7 +11,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
-      version = "~> 3.7"
+      version = "3.50" # Temporarily pinning the version here until this issue is resolved: https://github.com/hashicorp/terraform-provider-aws/issues/20787
     }
   }
 }

--- a/templates/terraform/environments/stage/main.tf
+++ b/templates/terraform/environments/stage/main.tf
@@ -11,7 +11,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
-      version = "~> 3.7"
+      version = "3.50" # Temporarily pinning the version here until this issue is resolved: https://github.com/hashicorp/terraform-provider-aws/issues/20787
     }
   }
 }


### PR DESCRIPTION
Temporarily pin the aws provider at 3.50 to prevent a regression affecting the DB after an auto  minor version upgrade.

https://github.com/hashicorp/terraform-provider-aws/issues/20787
