### PR TITLE
chore: bump cert manager version to try to prevent issue where it seems to get stuck not updating certs

### DIFF
--- a/templates/kubernetes/terraform/modules/kubernetes/cert_manager.tf
+++ b/templates/kubernetes/terraform/modules/kubernetes/cert_manager.tf
@@ -1,5 +1,5 @@
 locals {
-  cert_manager_version     = "1.4.0"
+  cert_manager_version     = "1.6.0"
   cluster_issuer_name      = var.cert_manager_use_production_acme_environment ? "clusterissuer-letsencrypt-production" : "clusterissuer-letsencrypt-staging"
   cert_manager_acme_server = var.cert_manager_use_production_acme_environment ? "https://acme-v02.api.letsencrypt.org/directory" : "https://acme-staging-v02.api.letsencrypt.org/directory"
 


### PR DESCRIPTION
We've seen issues where after a period of time cert-manager seems to get stuck in a state where it doesn't update certs until restarted. On newer EKS clusters we see it just repeating the following deprecation message in the logs:

```
networking.k8s.io/v1beta1 Ingress is deprecated in v1.19+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress
```﻿

